### PR TITLE
feat(STONEINTG-1364): add sanitize PLR for nightly build

### DIFF
--- a/.tekton/konflux-test-integration-e2e-push.yaml
+++ b/.tekton/konflux-test-integration-e2e-push.yaml
@@ -9,6 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "main"
+  finalizers:
+  - test.appstudio.openshift.io/pipelinerun
   labels:
     appstudio.openshift.io/application: konflux-test-integ-e2e
     appstudio.openshift.io/component: konflux-test-integration-e2e


### PR DESCRIPTION
to be cached as an OCI artifact in quay and reused for I.S. e2e testing without rebuilding.

Assisted by: Cursor AI